### PR TITLE
fix(core): open tabs consistently with revisionless app ids

### DIFF
--- a/electron/src/routes.ts
+++ b/electron/src/routes.ts
@@ -176,7 +176,6 @@ module.exports = {
             }
 
         }, err => {
-            console.log("Watch user error");
             callback(err)
         });
     },
@@ -296,7 +295,10 @@ module.exports = {
 
             swapController.exists(data.id, (err, exists) => {
 
-                if (err) return callback(err);
+                if (err) {
+                    callback(err);
+                    return;
+                }
 
                 if (exists) {
                     swapController.read(data.id, callback);
@@ -402,7 +404,6 @@ module.exports = {
             const originalUser = repository.user;
 
             const off = repository.on("update.user", (user) => {
-                console.log("user comparison", typeof user, typeof originalUser);
                 if (user !== originalUser) {
                     off();
                     // @FIXME hack for event receiving order, have no idea why it forks for the moment, figure it out later

--- a/src/app/core/code-content-service/code-content.service.ts
+++ b/src/app/core/code-content-service/code-content.service.ts
@@ -7,6 +7,7 @@ import "rxjs/add/operator/map";
 import {Observable} from "rxjs/Observable";
 import {ReplaySubject} from "rxjs/ReplaySubject";
 import {IpcService} from "../../services/ipc.service";
+import {AppHelper} from "../helpers/AppHelper";
 
 
 @Injectable()
@@ -34,7 +35,7 @@ export class CodeSwapService {
 
     private patchSwap(content): void {
         this.ipc.request("patchSwap", {
-            local: this.appID.startsWith("/"),
+            local: AppHelper.isLocal(this.appID),
             swapID: this.appID,
             swapContent: content
         });

--- a/src/app/core/helpers/AppHelper.ts
+++ b/src/app/core/helpers/AppHelper.ts
@@ -1,0 +1,13 @@
+export class AppHelper {
+    static isLocal(appID: string): boolean {
+
+        const isUnixPath    = appID.startsWith("/");
+        const isWindowsPath = (/^[a-z]:\\.+$/i).test(appID);
+
+        return isUnixPath || isWindowsPath;
+    }
+
+    static getRevisionlessID(appID: string): string {
+        return appID.split("/").slice(0, 3).join("/");
+    }
+}

--- a/src/app/core/modals/create-app-modal/create-app-modal.component.ts
+++ b/src/app/core/modals/create-app-modal/create-app-modal.component.ts
@@ -11,6 +11,7 @@ import {PlatformRepositoryService} from "../../../repository/platform-repository
 import {ModalService} from "../../../ui/modal/modal.service";
 import {DirectiveBase} from "../../../util/directive-base/directive-base";
 import {DataGatewayService} from "../../data-gateway/data-gateway.service";
+import {AppHelper} from "../../helpers/AppHelper";
 import {WorkboxService} from "../../workbox/workbox.service";
 
 const {app, dialog} = window["require"]("electron").remote;
@@ -273,13 +274,15 @@ export class CreateAppModalComponent extends DirectiveBase implements OnInit {
         const newAppID = `${this.projectSelection.value}/${slug}`.split("/").slice(0, 3).concat("0").join("/");
 
         this.platformRepository.createApp(newAppID, JSON.stringify(app, null, 4)).then(app => {
+
             const tab = this.workbox.getOrCreateAppTab({
-                id: newAppID,
+                id: AppHelper.getRevisionlessID(newAppID),
                 type: this.appType === "workflow" ? "Workflow" : "CommandLineTool",
                 label: label,
                 isWritable: true,
                 language: "json"
             });
+
             this.workbox.openTab(tab);
             this.modal.close();
 

--- a/src/app/core/panels/public-apps-panel/public-apps-panel.component.ts
+++ b/src/app/core/panels/public-apps-panel/public-apps-panel.component.ts
@@ -4,6 +4,7 @@ import {Observable} from "rxjs/Observable";
 import {App} from "../../../../../electron/src/sbg-api-client/interfaces/app";
 
 import {LocalFileRepositoryService} from "../../../file-repository/local-file-repository.service";
+import {LocalRepositoryService} from "../../../repository/local-repository.service";
 import {PlatformRepositoryService} from "../../../repository/platform-repository.service";
 import {TreeNode} from "../../../ui/tree-view/tree-node";
 import {TreeViewComponent} from "../../../ui/tree-view/tree-view.component";
@@ -13,7 +14,7 @@ import {TabData} from "../../workbox/tab-data.interface";
 import {WorkboxService} from "../../workbox/workbox.service";
 import {NavSearchResultComponent} from "../nav-search-result/nav-search-result.component";
 import {PublicAppsPanelService} from "./public-apps-panel.service";
-import {LocalRepositoryService} from "../../../repository/local-repository.service";
+import {AppHelper} from "../../helpers/AppHelper";
 
 @Component({
     selector: "ct-public-apps-panel",
@@ -114,7 +115,7 @@ export class PublicAppsPanelComponent extends DirectiveBase implements OnInit, A
 
     ngOnInit() {
 
-        this.localRepository.getPublicAppsGrouping().take(1).subscribeTracked(this, (grouping) =>{
+        this.localRepository.getPublicAppsGrouping().take(1).subscribeTracked(this, (grouping) => {
             this.grouping = grouping;
         });
 
@@ -146,14 +147,14 @@ export class PublicAppsPanelComponent extends DirectiveBase implements OnInit, A
             return apps.map(app => {
 
                 return {
-                    id: app.id,
+                    id: AppHelper.getRevisionlessID(app.id),
                     icon: app.raw["class"] === "Workflow" ? "fa-share-alt" : "fa-terminal",
                     title: app.name,
                     label: app.id.split("/").join(" → "),
                     relevance: 1.5,
 
                     tabData: {
-                        id: app.id,
+                        id: AppHelper.getRevisionlessID(app.id),
                         isWritable: false,
                         label: app.name,
                         language: "json",
@@ -201,13 +202,14 @@ export class PublicAppsPanelComponent extends DirectiveBase implements OnInit, A
         const appOpening = this.tree.open.filter(n => n.type === "app");
 
         appOpening.subscribeTracked(this, (node: TreeNode<App>) => {
+
             const app = node.data;
             if (!app.raw || !app.raw.class) {
                 return;
             }
 
             const tab = this.workbox.getOrCreateAppTab({
-                id: app.id,
+                id: AppHelper.getRevisionlessID(app.id),
                 language: "json",
                 isWritable: false,
                 type: app.raw.class,

--- a/src/app/core/panels/public-apps-panel/public-apps-panel.service.ts
+++ b/src/app/core/panels/public-apps-panel/public-apps-panel.service.ts
@@ -3,6 +3,7 @@ import {Observable} from "rxjs/Observable";
 import {App} from "../../../../../electron/src/sbg-api-client/interfaces/app";
 import {PlatformRepositoryService} from "../../../repository/platform-repository.service";
 import {TreeNode} from "../../../ui/tree-view/tree-node";
+import {AppHelper} from "../../helpers/AppHelper";
 
 @Injectable()
 export class PublicAppsPanelService {
@@ -138,7 +139,7 @@ export class PublicAppsPanelService {
         }
 
         return {
-            id: app.id,
+            id: AppHelper.getRevisionlessID(app.id),
             data: app,
             type: "app",
             label: app.name,

--- a/src/app/core/workbox/workbox.service.ts
+++ b/src/app/core/workbox/workbox.service.ts
@@ -7,6 +7,7 @@ import {RecentAppTab} from "../../../../electron/src/storage/types/recent-app-ta
 import {LocalRepositoryService} from "../../repository/local-repository.service";
 import {PlatformRepositoryService} from "../../repository/platform-repository.service";
 import {DataGatewayService} from "../data-gateway/data-gateway.service";
+import {AppHelper} from "../helpers/AppHelper";
 import {AppTabData} from "./app-tab-data";
 import {TabData} from "./tab-data.interface";
 
@@ -40,7 +41,7 @@ export class WorkboxService {
                 const {id, label, type, isWritable, language} = tab;
 
                 const entry = {id, label, type, isWritable, language, position};
-                if (entry.id.startsWith("/")) {
+                if (AppHelper.isLocal(entry.id)) {
                     localTabs.push(entry);
                 } else {
                     platformTabs.push(entry);
@@ -101,7 +102,7 @@ export class WorkboxService {
             time: Date.now()
         } as RecentAppTab;
 
-        if (tab.id.startsWith("/")) {
+        if (AppHelper.isLocal(tab.id)) {
             this.localRepository.pushRecentApp(recentTabData);
         } else {
             this.platformRepository.pushRecentApp(recentTabData);
@@ -182,14 +183,6 @@ export class WorkboxService {
         this.activeTab.next(tab);
     }
 
-    /**
-     * @deprecated Do this same thing with {@link getOrCreateAppTab}
-     * @param fileID
-     */
-    getOrCreateFileTabAndOpenIt(fileID) {
-        this.getOrCreateFileTab(fileID).take(1).subscribe((tab) => this.openTab(tab));
-    }
-
     getOrCreateAppTab<T>(data: {
         id: string;
         type: string;
@@ -198,18 +191,19 @@ export class WorkboxService {
         language?: string;
 
     }): TabData<T> {
+
+        console.log("Creating tab data", data);
         const currentTab = this.tabs.getValue().find(existingTab => existingTab.id === data.id);
 
         if (currentTab) {
             return currentTab;
         }
 
-
         const dataSource = DataGatewayService.getFileSource(data.id);
 
         const id         = data.id;
         const label      = data.id.split("/").pop();
-        const isWritable = data.isWritable === undefined ? dataSource !== "public" : data.isWritable;
+        const isWritable = data.isWritable;
 
         const fileContent = Observable.empty().concat(this.dataGateway.fetchFileContent(id));
         const resolve     = (fcontent: string) => this.dataGateway.resolveContent(fcontent, id);
@@ -233,74 +227,6 @@ export class WorkboxService {
 
         return tab;
 
-    }
-
-    /**
-     * @deprecated Use {@link getOrCreateAppTab} for synchronous tab opening version
-     */
-    getOrCreateFileTab(fileID): Observable<TabData<AppTabData>> {
-
-        const currentTab = this.tabs.getValue().find(tab => tab.id === fileID);
-
-        if (currentTab) {
-            return Observable.of(currentTab);
-        }
-
-
-        return this.dataGateway.fetchFileContent(fileID).map(content => {
-
-            const dataSource = DataGatewayService.getFileSource(fileID);
-
-            const tab = {
-                id: fileID,
-                label: fileID,
-                type: "Code",
-                isWritable: dataSource !== "public",
-                data: {
-                    id: fileID,
-                    isWritable: dataSource !== "public",
-                    dataSource,
-                    language: "yaml",
-                    parsedContent: {},
-                    fileContent: content,
-                    resolve: (fcontent: string) => this.dataGateway.resolveContent(fcontent, fileID)
-                }
-            };
-
-            if (fileID.endsWith(".json")) {
-                tab.data.language = "json";
-            }
-
-            try {
-
-                const parsed = YAML.safeLoad(content, {json: true} as any);
-
-                tab.data.parsedContent = parsed;
-
-                if (dataSource === "public") {
-                    tab.id = parsed.id;
-                }
-
-                if (dataSource !== "local") {
-                    tab.data.fileContent = JSON.stringify(parsed, null, 4);
-                }
-
-                tab.label = parsed.label || fileID;
-
-                if (["CommandLineTool", "Workflow"].indexOf(parsed.class) !== -1) {
-                    tab.type = parsed.class;
-                }
-            } catch (ex) {
-                console.warn("Could not parse app", ex);
-            }
-
-            if (dataSource === "local") {
-                tab.label = fileID.split("/").pop();
-            }
-
-            return tab as any;
-
-        });
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where platform apps would be opened by tab ids that contain app revision numbers.
Consequentially, swap files would refer to revisions and you would be unable to switch back to the latest revision after switching to an older one.
