### PR TITLE
fix(core): update welcome page to connect to platform

### DIFF
--- a/src/app/core/onboarding/welcome.component.spec.ts
+++ b/src/app/core/onboarding/welcome.component.spec.ts
@@ -6,8 +6,8 @@ import {NativeModule} from "../../native/native.module";
 import {SystemService} from "../../platform-providers/system.service";
 
 import {ModalService} from "../../ui/modal/modal.service";
-import {AddSourceModalComponent} from "../modals/add-source-modal/add-source-modal.component";
 import {WelcomeTabComponent} from "./welcome.component";
+import {PlatformCredentialsModalComponent} from "../modals/platform-credentials-modal/platform-credentials-modal.component";
 
 describe("WelcomeComponent", () => {
     let component: WelcomeTabComponent;
@@ -54,16 +54,16 @@ describe("WelcomeComponent", () => {
         expect(firstArg.startsWith("http://rabix.io")).toBe(true);
     });
 
-    it("should open modal when click on 'Open a Project' button", () => {
+    it("should open modal when click on 'Connect to Platform' button", () => {
 
         const modal = fixture.debugElement.injector.get(ModalService);
 
         const modalSpy       = spyOn(modal, "fromComponent");
-        const openProjectBtn = fixture.debugElement.query(By.css("[data-test='open-project-btn']"));
+        const openProjectBtn = fixture.debugElement.query(By.css("[data-test='connect-to-platform-btn']"));
 
         openProjectBtn.triggerEventHandler("click", {});
 
         expect(modalSpy).toHaveBeenCalledTimes(1);
-        expect(modalSpy).toHaveBeenCalledWith(AddSourceModalComponent, jasmine.anything());
+        expect(modalSpy).toHaveBeenCalledWith(PlatformCredentialsModalComponent, jasmine.anything());
     });
 });

--- a/src/app/core/onboarding/welcome.component.ts
+++ b/src/app/core/onboarding/welcome.component.ts
@@ -2,6 +2,7 @@ import {Component} from "@angular/core";
 import {AddSourceModalComponent} from "../modals/add-source-modal/add-source-modal.component";
 import {SystemService} from "../../platform-providers/system.service";
 import {ModalService} from "../../ui/modal/modal.service";
+import {PlatformCredentialsModalComponent} from "../modals/platform-credentials-modal/platform-credentials-modal.component";
 
 @Component({
     styleUrls: ["welcome.component.scss"],
@@ -14,7 +15,8 @@ import {ModalService} from "../../ui/modal/modal.service";
             <div class="background-logo"></div>
 
             <div class="content">
-                <p class="welcome-text">The Rabix Composer is a standalone integrated development environment for workflow
+                <p class="welcome-text">The Rabix Composer is a standalone integrated development
+                    environment for workflow
                     description languages that enables rapid workflow composition, testing, and
                     integration
                     with online services like DockerHub.
@@ -30,10 +32,10 @@ import {ModalService} from "../../ui/modal/modal.service";
                 </h2>
 
                 <p>
-                    <button data-test="open-project-btn" type="button"
-                            (click)="onOpenProjectButtonClick()"
+                    <button data-test="connect-to-platform-btn" type="button"
+                            (click)="onConnectButtonClick()"
                             class="btn btn-primary">
-                        Open a Project
+                        Connect to Platform
                     </button>
                 </p>
             </div>
@@ -49,7 +51,7 @@ export class WelcomeTabComponent {
                 private modal: ModalService) {
     }
 
-    onOpenProjectButtonClick() {
-        this.modal.fromComponent(AddSourceModalComponent, "Open a Project");
+    onConnectButtonClick() {
+        this.modal.fromComponent(PlatformCredentialsModalComponent, "Add Connection");
     }
 }


### PR DESCRIPTION
"Open a Project" on the welcome page is changed to "Connect to Platform" which opens the add connection dialog to facilitate onboarding platform users.