### PR TITLE
fix(core): update modal image missing

### DIFF
--- a/src/app/core/modals/update-platform-modal/update-platform-modal.component.scss
+++ b/src/app/core/modals/update-platform-modal/update-platform-modal.component.scss
@@ -29,8 +29,6 @@
     .logo {
         height: 100px;
         width: 100px;
-        background: url("../../../../assets/img/rc_icon_256x256.png") no-repeat center;
-        background-size: contain;
     }
 
     .dialog-content {

--- a/src/app/core/modals/update-platform-modal/update-platform-modal.component.ts
+++ b/src/app/core/modals/update-platform-modal/update-platform-modal.component.ts
@@ -11,8 +11,7 @@ import {SystemService} from "../../../platform-providers/system.service";
 
             <div class="header">
                 
-                <div class="logo mb-1">                    
-                </div>
+                <img class="logo mb-1" src="../../../../assets/img/rc_icon_256x256.png">                    
 
                 <div class="header-text">                    
                     <ng-container *ngIf="platformIsOutdated; else upToDate">


### PR DESCRIPTION
Appears to be related to angular/angular-cli/issues/4806 issue with AoT compilation. Adding the image as an HTML `<img/>` element seems  to fix it.