### PR TITLE
make local workflow composition reference relative paths

### DIFF
--- a/electron/src/schema-salad-resolver/schema-salad-resolver.ts
+++ b/electron/src/schema-salad-resolver/schema-salad-resolver.ts
@@ -98,7 +98,6 @@ function traverse(data, source, root, rootPath, graph = {}, traversedExternalPat
 
                     traversed.add(externalPath);
 
-                    console.log("Fetching external", externalPath);
                     const type = key === "$include" ? "text" : "json";
                     fetch(externalPath, {type}, rootPath, traversed).then((content) => {
 
@@ -137,7 +136,6 @@ function traverse(data, source, root, rootPath, graph = {}, traversedExternalPat
                                     "sbg:rdfId": entry,
                                     "sbg:rdfSource": externalPath
                                 });
-                                console.log("After run parsed", data);
                                 break;
                         }
 

--- a/src/app/tool-editor/sections/file-def-list/file-def-list.component.ts
+++ b/src/app/tool-editor/sections/file-def-list/file-def-list.component.ts
@@ -31,10 +31,8 @@ import {DirectiveBase} from "../../../util/directive-base/directive-base";
 
                         <!--In case that tool is not draft2 then show dropdown for adding items-->
                         <ct-generic-dropdown-menu [ct-menu]="menu" #addItemDropDown>
-                            <button class="btn btn-primary"
-                                    data-test="file-requirement-add-button"
-                                    type="button" (click)="addItemDropDown.toggleMenu()">Add
-                            </button>
+                            <button class="btn btn-primary" type="button" data-test="file-requirement-add-button"  
+                                    (click)="addItemDropDown.toggleMenu()">Add</button>
                         </ct-generic-dropdown-menu>
 
                         <!--Template for add item dropdown -->

--- a/src/app/workflow-editor/graph-editor/graph-editor/workflow-graph-editor.component.ts
+++ b/src/app/workflow-editor/graph-editor/graph-editor/workflow-graph-editor.component.ts
@@ -57,8 +57,7 @@ export class WorkflowGraphEditorComponent extends DirectiveBase implements OnCha
 
     @Input() model: WorkflowModel;
 
-    @Input()
-    host: WorkflowEditorComponent;
+    @Input() host: WorkflowEditorComponent;
 
     @Input() data: AppTabData;
 
@@ -85,7 +84,6 @@ export class WorkflowGraphEditorComponent extends DirectiveBase implements OnCha
 
     @ViewChild("inspector", {read: TemplateRef})
     private inspectorTemplate: TemplateRef<any>;
-
 
     private historyHandler: (ev: KeyboardEvent) => void;
 
@@ -325,16 +323,16 @@ export class WorkflowGraphEditorComponent extends DirectiveBase implements OnCha
     /**
      * Triggers when app is dropped on canvas
      */
-    onDrop(ev: MouseEvent, nodeData: {name: string, type: "cwl" | "directory" | "file"}) {
+    onDrop(ev: MouseEvent, nodeData: { name: string, type: "cwl" | "directory" | "file" }) {
         if (this.readonly || nodeData.type !== "cwl") {
             return;
         }
 
         const statusProcess = this.statusBar.startProcess(`Adding ${nodeData.name} to Workflow...`);
 
-        const isLocal = AppHelper.isLocal(nodeData.name);
+        const droppedIsLocal = AppHelper.isLocal(nodeData.name);
 
-        const fetch: Promise<string> = isLocal
+        const fetch: Promise<string> = droppedIsLocal
             ? this.fileRepository.fetchFile(nodeData.name)
             : this.platformRepository.getApp(nodeData.name).then(app => JSON.stringify(app));
 
@@ -353,8 +351,9 @@ export class WorkflowGraphEditorComponent extends DirectiveBase implements OnCha
                     });
             })
             .then((resolved: Process) => {
+
                 // if the app is local, give it an id that's the same as its filename (if doesn't exist)
-                if (isLocal) {
+                if (droppedIsLocal) {
                     resolved.id = resolved.id || AppHelper.getBasename(nodeData.name, true);
                 }
 
@@ -369,9 +368,30 @@ export class WorkflowGraphEditorComponent extends DirectiveBase implements OnCha
                 const step = this.model.addStepFromProcess(patched);
 
                 // add local source so step can be serialized without embedding
-                if (isLocal) {
+                if (droppedIsLocal) {
+                    const editedAppIsLocal = AppHelper.isLocal(this.data.id);
+                    let rdfID              = nodeData.name;
+
+                    /**
+                     * If we are dropping a local app onto another local app, it should be referenced by a relative path
+                     * FIXME: Do not require path here, have it as an optional dependency
+                     */
+                    if (editedAppIsLocal) {
+
+                        const {relative, dirname, basename} = window["require"]("path");
+
+                        const originalDir   = dirname(this.data.id);
+                        const addedDir      = dirname(rdfID);
+                        const addedBasename = basename(rdfID);
+                        // If files are in the same directory, relative path will be an empty string,
+                        // so we need to avoid having “/{basename}”, and make it be “./{basename}”
+                        const relativePath = relative(originalDir, addedDir) || ".";
+
+                        rdfID = relativePath + "/" + addedBasename;
+                    }
+
+                    step.customProps["sbg:rdfId"]     = rdfID;
                     step.customProps["sbg:rdfSource"] = nodeData.name;
-                    step.customProps["sbg:rdfId"]     = nodeData.name;
                 }
 
                 this.change.emit();
@@ -524,7 +544,8 @@ export class WorkflowGraphEditorComponent extends DirectiveBase implements OnCha
             }, err => {
                 this.notificationBar.showNotification("Could not save SVG: " + err, {timeout: 50000});
             });
-        }, () => {});
+        }, () => {
+        });
 
     }
 


### PR DESCRIPTION
When dropping an app onto a workflow, in case they are both local, now we figure out a relative path from the edited app to the added one and add it to the model instead of the absolute one.
Also, some comments are added to rdf resolver.