### PR TITLE
consistently prompt for destination file path when creating apps

### DIFF
--- a/src/app/core/modals/create-app-modal/create-app-modal.component.scss
+++ b/src/app/core/modals/create-app-modal/create-app-modal.component.scss
@@ -1,5 +1,7 @@
 @import "../../../../assets/sass/variables";
 
+$project-list-status-text-color: $text-muted !default;
+
 :host {
     display:block;
     width: 500px;
@@ -8,6 +10,11 @@
         width: 100%;
         height: 80px;
         display: flex;
+    }
+
+    .project-list-status {
+        float: right;
+        color: $project-list-status-text-color;
     }
 
     .platform {

--- a/src/app/core/modals/create-app-modal/create-app-modal.component.ts
+++ b/src/app/core/modals/create-app-modal/create-app-modal.component.ts
@@ -77,19 +77,11 @@ import {map, take, startWith, switchMap} from "rxjs/operators";
                                       data-test="new-app-destination-project"></ct-auto-complete>
 
                     <p class="project-list-status">
-
-                        <ng-container *ngIf="isShowingAllProjects">Showing all projects.</ng-container>
-                        <ng-container *ngIf="!isShowingAllProjects">Showing added projects.</ng-container>
-
-                        <ng-container *ngIf="canToggleShowingAllProjects">
-                            <button *ngIf="isShowingAllProjects" type="button" class="btn btn-link btn-inline-link"
-                                    (click)="toggleShowingAllProjects.emit(false)">Show added.
-                            </button>
-                            <button *ngIf="!isShowingAllProjects" type="button" class="btn btn-link btn-inline-link"
-                                    (click)="toggleShowingAllProjects.emit(true)">Show all.
-                            </button>
-                        </ng-container>
-
+                        Showing {{ isShowingAllProjects ? 'all' : 'added' }} projects.
+                        <button type="button" class="btn btn-link btn-inline-link"
+                                (click)="toggleShowingAllProjects.emit(!isShowingAllProjects)">
+                            Show {{ isShowingAllProjects ? 'added' : 'all' }}
+                        </button>
                     </p>
                 </div>
 

--- a/src/app/core/modals/create-app-modal/create-app-modal.component.ts
+++ b/src/app/core/modals/create-app-modal/create-app-modal.component.ts
@@ -43,7 +43,7 @@ import {map, take, startWith, switchMap} from "rxjs/operators";
 
                 <div class="form-group">
                     <label>App Name:</label>
-                    <input class="form-control" data-test="new-app-name"
+                    <input class="form-control" data-test="new-app-name" autofocus
                            placeholder="My New {{ destination === 'remote' ? remoteForm.get('type').value : localForm.get('type').value }}"
                            formControlName="name"/>
                     <p *ngIf="destination === 'remote' && remoteForm.get('name').value" class="form-text text-muted">

--- a/src/app/core/panels/my-apps-panel/my-apps-panel.component.ts
+++ b/src/app/core/panels/my-apps-panel/my-apps-panel.component.ts
@@ -303,7 +303,8 @@ export class MyAppsPanelComponent extends DirectiveBase implements AfterContentI
                     this.modal.fromComponent(CreateAppModalComponent, `Create a new ${type} in ${node.label}`, {
                         appType: type,
                         destination,
-                        defaultFolder: node.id
+                        defaultFolder: destination === "local" ? node.id : undefined,
+                        defaultProject: destination === "remote" ? node.id : undefined
                     });
                 }
             });

--- a/src/app/core/panels/my-apps-panel/my-apps-panel.component.ts
+++ b/src/app/core/panels/my-apps-panel/my-apps-panel.component.ts
@@ -272,7 +272,7 @@ export class MyAppsPanelComponent extends DirectiveBase implements AfterContentI
         const platformRootMenuItems = [
             new MenuItem("Open a Project", {
                 click: () => {
-                    const component = this.modal.fromComponent(AddSourceModalComponent, "Open a Project");
+                    const component     = this.modal.fromComponent(AddSourceModalComponent, "Open a Project");
                     component.activeTab = "platform";
                 }
             }),
@@ -300,21 +300,11 @@ export class MyAppsPanelComponent extends DirectiveBase implements AfterContentI
 
             return new MenuItem(`New ${type}`, {
                 click: () => {
-                    const modal = this.modal.fromComponent(CreateAppModalComponent, `Create a new ${type} in ${node.label}`);
-
-                    modal.appType     = type;
-                    modal.destination = destination;
-                    if (destination === "local") {
-                        modal.defaultFolder = node.id;
-
-                        // Wait for component to initialize, then open the dialog for choosing the file path
-                        setTimeout(() => {
-                            modal.chooseFilepath();
-                        });
-                    } else {
-                        modal.defaultProject = node.id;
-                    }
-
+                    this.modal.fromComponent(CreateAppModalComponent, `Create a new ${type} in ${node.label}`, {
+                        appType: type,
+                        destination,
+                        defaultFolder: node.id
+                    });
                 }
             });
         };

--- a/src/app/ui/autofocus/autofocus.directive.ts
+++ b/src/app/ui/autofocus/autofocus.directive.ts
@@ -1,0 +1,14 @@
+import {Directive, ElementRef, OnInit} from "@angular/core";
+
+@Directive({
+    selector: "[ct-autofocus], [autofocus]"
+})
+export class AutofocusDirective implements OnInit {
+
+    constructor(private elementRef: ElementRef) {
+    }
+
+    ngOnInit() {
+        this.elementRef.nativeElement.focus();
+    }
+}

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -52,6 +52,7 @@ import {TreeNodeComponent} from "./tree-view/tree-node/tree-node.component";
 import {TreeViewComponent} from "./tree-view/tree-view.component";
 import {NativeFileBrowserFormFieldComponent} from "./native-file-browser-form-field/native-file-browser-form-field.component";
 import {BlankStateComponent} from "./blank-state/blank-state.component";
+import {AutofocusDirective} from "./autofocus/autofocus.directive";
 
 @NgModule({
     imports: [
@@ -61,6 +62,7 @@ import {BlankStateComponent} from "./blank-state/blank-state.component";
     ],
     exports: [
         AutoCompleteComponent,
+        AutofocusDirective,
         BlankStateComponent,
         BlockLoaderComponent,
         LineLoaderComponent,
@@ -167,6 +169,7 @@ import {BlankStateComponent} from "./blank-state/blank-state.component";
         TreeNodeLabelDirective,
         TreeViewComponent,
         TrimValueAccessor,
+        AutofocusDirective,
     ]
 })
 export class UIModule {


### PR DESCRIPTION
Opening the native file path window is moved from myAppsPanel click event to the modal itself and is triggered whenever you create a new modal for local destination.
Also, chosen file path is converted to title case if you didn't already set the app name.