### PR TITLE
don't try to remove json extension while searching for profile files …

### DIFF
--- a/electron/src/routes.ts
+++ b/electron/src/routes.ts
@@ -8,7 +8,6 @@ import {AppQueryParams} from "./sbg-api-client/interfaces/queries";
 import {SBGClient} from "./sbg-api-client/sbg-client";
 import {DataRepository} from "./storage/data-repository";
 import {ExecutorDefaultPathLoader} from "./storage/hooks/executor-config-hook";
-import {AppMetaEntry} from "./storage/types/app-meta";
 import {CredentialsCache, LocalRepository} from "./storage/types/local-repository";
 import {UserRepository} from "./storage/types/user-repository";
 import {heal} from "./storage/repository-healer";
@@ -19,14 +18,13 @@ const swapPath       = userDataPath + path.sep + "swap";
 const swapController = new SwapController(swapPath);
 
 const fsController          = require("./controllers/fs.controller");
-const executionResultsCtrl  = require("./controllers/execution-results.controller");
 const acceleratorController = require("./controllers/accelerator.controller");
 
-const deepLinkingProtocolController  = require("./controllers/open-external-file/deep-linking-protocol-controller");
-const openFileHandlerController = require("./controllers/open-external-file/open-file-handler-controller");
+const deepLinkingProtocolController = require("./controllers/open-external-file/deep-linking-protocol-controller");
+const openFileHandlerController     = require("./controllers/open-external-file/open-file-handler-controller");
 
-const resolver              = require("./schema-salad-resolver/schema-salad-resolver");
-const semver                = require("semver");
+const resolver = require("./schema-salad-resolver/schema-salad-resolver");
+const semver   = require("semver");
 
 let repository: DataRepository;
 let repositoryLoad: Promise<any>;
@@ -52,24 +50,24 @@ export function loadDataRepository() {
 
     repository.attachHook(new ExecutorDefaultPathLoader());
 
-    repositoryLoad = new Promise((resolve, reject) => {
+    repositoryLoad = new Promise((resolveLoad, rejectLoad) => {
         repository.load(err => {
             if (err) {
-                return reject(err);
+                return rejectLoad(err);
             }
 
             heal(repository.local).then(isModified => {
                 if (isModified) {
                     repository.updateLocal(repository.local, () => {
-                        resolve(1);
+                        resolveLoad(1);
                     });
                 }
 
-                resolve(1);
+                resolveLoad(1);
             });
 
         });
-    }).catch(err => void 0);
+    }).catch(() => void 0);
 }
 
 // File System Routes
@@ -106,8 +104,8 @@ export function pathExists(path, callback) {
     fsController.pathExists(path, callback);
 }
 
-export function resolve(path, callback: (err?: Error, result?: Object) => void) {
-    resolver.resolve(path).then(result => {
+export function resolve(filepath, callback: (err?: Error, result?: Object) => void) {
+    resolver.resolve(filepath).then(result => {
         callback(null, result);
     }, err => {
         callback(err);

--- a/electron/src/storage/data-repository.ts
+++ b/electron/src/storage/data-repository.ts
@@ -360,7 +360,6 @@ export class DataRepository {
             }
 
             const deletables = files
-                .map(file => file.slice(0, -5)) // remove .json extension
                 .filter(profile => profile !== "local" && profileIDs.indexOf(profile) === -1) // take just the ones not present in profiles
                 .map(profile => new Promise((resolve, reject) => {
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,13 +31,10 @@ import {FileOpenerToken, DirectoryExplorerToken} from "./execution/interfaces";
 import {NativeSystemService} from "./native/system/native-system.service";
 import {WorkboxService} from "./core/workbox/workbox.service";
 import {directoryExplorerFactory, fileOpenerFactory} from "./factories/execution";
+import {credentialsRegistryFactory} from "./factories/auth";
 
 @NgModule({
     providers: [
-        {
-            provide: CREDENTIALS_REGISTRY,
-            useClass: LocalRepositoryService
-        },
         AuthService,
         DataGatewayService,
         DomEventService,
@@ -48,22 +45,15 @@ import {directoryExplorerFactory, fileOpenerFactory} from "./factories/execution
         IpcService,
         JavascriptEvalService,
         LocalRepositoryService,
-        OpenExternalFileService,
         ModalService,
+        OpenExternalFileService,
         PlatformConnectionService,
         PlatformRepositoryService,
         SettingsService,
         StatusBarService,
-        {
-            provide: DirectoryExplorerToken,
-            useFactory: directoryExplorerFactory,
-            deps: [NativeSystemService]
-        },
-        {
-            provide: FileOpenerToken,
-            useFactory: fileOpenerFactory,
-            deps: [WorkboxService]
-        }
+        {provide: CREDENTIALS_REGISTRY, useFactory: credentialsRegistryFactory, deps: [LocalRepositoryService]},
+        {provide: DirectoryExplorerToken, useFactory: directoryExplorerFactory, deps: [NativeSystemService]},
+        {provide: FileOpenerToken, useFactory: fileOpenerFactory, deps: [WorkboxService]}
     ],
     declarations: [
         MainComponent,

--- a/src/app/auth/credentials-registry.ts
+++ b/src/app/auth/credentials-registry.ts
@@ -3,7 +3,6 @@ import {AuthCredentials} from "./model/auth-credentials";
 
 export interface CredentialsRegistry {
 
-
     getCredentials(): Observable<AuthCredentials[]>;
 
     setCredentials(credentials: AuthCredentials[]): Promise<any>;
@@ -11,5 +10,4 @@ export interface CredentialsRegistry {
     getActiveCredentials(): Observable<AuthCredentials>;
 
     setActiveCredentials(credentials: AuthCredentials | null): Promise<any>;
-
 }

--- a/src/app/factories/auth.ts
+++ b/src/app/factories/auth.ts
@@ -1,0 +1,20 @@
+import {LocalRepositoryService} from "../repository/local-repository.service";
+import {CredentialsRegistry} from "../auth/credentials-registry";
+import {AuthCredentials} from "../auth/model/auth-credentials";
+
+export const credentialsRegistryFactory = (localRepository: LocalRepositoryService) => {
+    return {
+        getActiveCredentials() {
+            return localRepository.getActiveCredentials();
+        },
+        getCredentials() {
+            return localRepository.getCredentials();
+        },
+        setActiveCredentials(credentials: AuthCredentials) {
+            return localRepository.setActiveCredentials(credentials);
+        },
+        setCredentials(credentials: AuthCredentials[]) {
+            return localRepository.setCredentials(credentials);
+        }
+    } as CredentialsRegistry;
+};


### PR DESCRIPTION
Actual fix is just this single line:
https://github.com/rabix/composer/pull/351/files#diff-646e1fed1f8bfba9571b303738757463L363

Other stuff are unshadowing a couple of variables and moving a CREDENTIALS_REGISTRY provider to a factory instead of passing the whole LocalRepositoryService. 
Before doing this, auth-related methods that were being used from the LocalRepository were marked as unused by tooling. Now they are explicitly wired up in the factory, and detected.