### PR TITLE
Open directory with a desktop-agnostic command

### DIFF
--- a/electron/src/utils/file-explorer-opener.ts
+++ b/electron/src/utils/file-explorer-opener.ts
@@ -13,5 +13,5 @@ export function open(target) {
         return;
     }
 
-    spawn(isMac ? "open" : "nautilus", [target], {detached: true});
+    spawn(isMac ? "open" : "xdg-open", [target], {detached: true});
 }


### PR DESCRIPTION
using xdg-open enables to open the job directory without failing in Linux, even if the default file browser is not Nautilus.