### PR TITLE
Renaming the artifact name for linux following standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ yarn run build
 yarn test
 ```
 
+## Running a released version of the Composer
+
+Donwload the releases packaged for the environment you are using:
+
+### MacOs
+
+Download the `rabix-composer-VERSION.dmg`, and double click on it
+
+### Windows
+
+Download the `rabix-composer.Setup.VERSION.exe` and double click on it
+
+### Linux
+
+Donwload the `rabix-composer-VERSION-x86_64.AppImage`, make it executable and then
+launch it via the commandline (or double click on it, and execute it).
+
+```
+    chmod +x rabix-composer-VERSION-x86_64.AppImage
+    ./rabix-composer-VERSION-x86_64.AppImage
+```
+
 ## Documentation
 
 Now you can read the [Rabix Composer documentation](http://docs.rabix.io/) to learn more about Rabix Composer.

--- a/electron-build.js
+++ b/electron-build.js
@@ -76,8 +76,7 @@ builder.build({
             target: ["nsis"],
         },
         linux: {
-            target: ["AppImage"],
-            artifactName : "${productName}-${version}-${arch}.sh"
+            target: ["AppImage"]
         },
         nsis: {
             oneClick: false,

--- a/electron-build.js
+++ b/electron-build.js
@@ -76,7 +76,7 @@ builder.build({
             target: ["nsis"],
         },
         linux: {
-            target: ["AppImage"]
+            target: ["AppImage"],
         },
         nsis: {
             oneClick: false,

--- a/electron-build.js
+++ b/electron-build.js
@@ -77,6 +77,7 @@ builder.build({
         },
         linux: {
             target: ["AppImage"],
+            artifactName : "${productName}-${version}-${arch}.sh"
         },
         nsis: {
             oneClick: false,


### PR DESCRIPTION
The artifcat built is a binary, which should be launched directly
from the console. Electron default is to have the AppImage extension
which however is not used a lot in the linux world.

The proposed changed aligns the name to a more classic approach.