### PR TITLE
build(electron): Bump Electron to v2

### DIFF
--- a/electron/src/splash/index.html
+++ b/electron/src/splash/index.html
@@ -140,7 +140,6 @@
 </div>
 <script>
     const webFrame = require("electron").webFrame;
-    webFrame.setZoomLevelLimits(1, 1);
     webFrame.setVisualZoomLevelLimits(1, 1);
     webFrame.setLayoutZoomLevelLimits(1, 1);
 </script>

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "archiver": "^2.1.1",
         "codelyzer": "^4.0.1",
         "concurrently": "^3.5.0",
-        "electron": "1.7.12",
+        "electron": "2.0.18",
         "electron-builder": "20.44.4",
         "electron-notarize": "^0.2.1",
         "fs-extra": "^4.0.1",

--- a/src/app/platform-providers/electron-system.service.ts
+++ b/src/app/platform-providers/electron-system.service.ts
@@ -7,7 +7,7 @@ const {shell, webFrame} = window["require"]("electron");
 export class ElectronSystemService extends SystemService {
 
     boot() {
-        webFrame.setZoomLevelLimits(1, 1);
+        webFrame.setVisualZoomLevelLimits(1, 1);
     }
 
     openLink(url: string, event?: MouseEvent) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,9 +464,10 @@
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
 
-"@types/node@^7.0.18":
-  version "7.0.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.52.tgz#8990d3350375542b0c21a83cd0331e6a8fc86716"
+"@types/node@^8.0.24":
+  version "8.10.61"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.61.tgz#d299136ce54bcaf1abaa4a487f9e4bedf6b0d393"
+  integrity sha512-l+zSbvT8TPRaCxL1l9cwHCb0tSqGAGcjPJFItGGYat5oCTiq1uQQKYg5m7AF1mgnEBzFXGLJ2LRmNjtreRX76Q==
 
 "@types/node@^9.4.0":
   version "9.4.0"
@@ -3696,11 +3697,12 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.31"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz#00d832cba9fe2358652b0c48a8816c8e3a037e9f"
 
-electron@1.7.12:
-  version "1.7.12"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.12.tgz#dcc61a2c1b0c3df25f68b3425379a01abd01190e"
+electron@2.0.18:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.18.tgz#52f1b248c3cc013b5a870094de3b6ba5de313a0f"
+  integrity sha512-PQRHtFvLxHdJzMMIwTddUtkS+Te/fZIs+PHO+zPmTUTBE76V3Od3WRGzMQwiJHxN679licmCKhJpMyxZfDEVWQ==
   dependencies:
-    "@types/node" "^7.0.18"
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
This addresses the `Harfbuzz version too old (1.4.2)` error by bumping
the underlying electron dependency to the next major version, v2.

Fixed the underyling calls to `setZoomLevelLimits` with
`setVisualZoomLevelLimits`.

See https://www.electronjs.org/docs/breaking-changes#webcontents